### PR TITLE
feat: return up-to-date values

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ const { ok, error } = await kv.setAtomic(
 | -------- | --------- | ------------------------------------------------------ |
 | `ok`     | `boolean` | Whether the update was successful.                     |
 | `error`  | `string`  | The error message if the update failed or was aborted. |
+| `value`  | `unknown` | The new value in Deno KV                               |
 
 ### `setSafeAtomicMany`
 
@@ -96,10 +97,11 @@ const { ok, error } = await kv.setAtomicMany(
 
 #### 📦 Return object
 
-| Property | Type      | Description                                            |
-| -------- | --------- | ------------------------------------------------------ |
-| `ok`     | `boolean` | Whether the update was successful.                     |
-| `error`  | `string`  | The error message if the update failed or was aborted. |
+| Property  | Type      | Description                                            |
+| --------- | --------- | ------------------------------------------------------ |
+| `ok`      | `boolean` | Whether the update was successful.                     |
+| `error`   | `string`  | The error message if the update failed or was aborted. |
+| `values`  | `unknown` | The new values in Deno KV                              |
 
 #### 📚 Complex example
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ const { ok, error } = await kv.setAtomicMany(
 
 #### 📦 Return object
 
-| Property  | Type      | Description                                            |
-| --------- | --------- | ------------------------------------------------------ |
-| `ok`      | `boolean` | Whether the update was successful.                     |
-| `error`   | `string`  | The error message if the update failed or was aborted. |
-| `values`  | `unknown` | The new values in Deno KV                              |
+| Property | Type      | Description                                            |
+| -------- | --------- | ------------------------------------------------------ |
+| `ok`     | `boolean` | Whether the update was successful.                     |
+| `error`  | `string`  | The error message if the update failed or was aborted. |
+| `values` | `unknown` | The new values in Deno KV                              |
 
 #### 📚 Complex example
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Upgrade your Deno KV code with **confidence** and **peace of mind**.
 ## 🎁 A quick demo
 
 ```js
-import { withSafeAtomics } from "https://deno.land/x/kvp/mod.ts";
+import { withSafeAtomics } from "https://deno.land/x/kvp@1.1.0/mod.ts";
 
 // Create a KV instance with atomic support
 const kv = withSafeAtomics(await Deno.openKv());
@@ -46,7 +46,7 @@ A convenient version of `setSafeAtomicMany` for updating just one key. This func
 #### 🌟 Starter template
 
 ```ts
-import { withSafeAtomics } from "https://deno.land/x/kvp/mod.ts";
+import { withSafeAtomics } from "https://deno.land/x/kvp@1.1.0/mod.ts";
 
 const kv = withSafeAtomics(await Deno.openKv());
 
@@ -77,7 +77,7 @@ const { ok, error } = await kv.setAtomic(
 #### 🌟 Starter template
 
 ```ts
-import { withSafeAtomics } from "https://deno.land/x/kvp/mod.ts";
+import { withSafeAtomics } from "https://deno.land/x/kvp@1.1.0/mod.ts";
 
 const kv = withSafeAtomics(await Deno.openKv());
 
@@ -106,7 +106,7 @@ const { ok, error } = await kv.setAtomicMany(
 #### 📚 Complex example
 
 ```js
-import { withSafeAtomics } from "https://deno.land/x/kvp/mod.ts";
+import { withSafeAtomics } from "https://deno.land/x/kvp@1.1.0/mod.ts";
 
 // Create a KV instance with atomicMany support
 const kv = withSafeAtomics(await Deno.openKv());

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,10 @@
     "https://deno.land/std@0.190.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
     "https://deno.land/std@0.190.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
     "https://deno.land/std@0.190.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.190.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
+    "https://deno.land/std@0.190.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
+    "https://deno.land/std@0.191.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.191.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.191.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.191.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
   }
 }

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -85,7 +85,7 @@ Deno.test(
 
     // Assert
     assertEquals(newValue, mockValue);
-    assertEquals(result, { ok: false, error: abortReason, value: mockValue })
+    assertEquals(result, { ok: false, error: abortReason, value: mockValue });
   },
 );
 

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -27,12 +27,13 @@ Deno.test("setSafeAtomic update the values", async () => {
 
   // Act
   const kv = withSafeAtomics(await Deno.openKv());
-  await kv.setSafeAtomic(mockKey, updateValue);
+  const result = await kv.setSafeAtomic(mockKey, updateValue);
   const { value: newValue } = await kv.get(mockKey);
   await kv.close();
 
   // Assert
   assertEquals(newValue, mockValue);
+  assertEquals(result, { ok: true, error: null, value: newValue });
 });
 
 Deno.test("setSafeAtomicMany updates multiple values", async () => {
@@ -49,7 +50,7 @@ Deno.test("setSafeAtomicMany updates multiple values", async () => {
 
   // Act
   const kv = withSafeAtomics(await Deno.openKv());
-  await kv.setSafeAtomicMany(keys, updateValues, retryCount);
+  const result = await kv.setSafeAtomicMany(keys, updateValues, retryCount);
   const { value: newValue1 } = await kv.get(mockKey1);
   const { value: newValue2 } = await kv.get(mockKey2);
   await kv.close();
@@ -57,6 +58,7 @@ Deno.test("setSafeAtomicMany updates multiple values", async () => {
   // Assert
   assertEquals(newValue1, mockUpdatedValue1);
   assertEquals(newValue2, mockUpdatedValue2);
+  assertEquals(result, { ok: true, error: null, values: [newValue1, newValue2] });
 });
 
 Deno.test(
@@ -66,9 +68,10 @@ Deno.test(
     const mockKey = ["test", "abc"];
     const mockValue = "123";
     const mockUpdatedValue = "new value";
+    const abortReason = "Testing";
 
-    const updateValue = (_value: unknown, abort: () => void): unknown => {
-      abort();
+    const updateValue = (_value: unknown, abort: (reason?: string) => void): unknown => {
+      abort(abortReason);
 
       return mockUpdatedValue;
     };
@@ -76,12 +79,13 @@ Deno.test(
     // Act
     const kv = withSafeAtomics(await Deno.openKv());
     await kv.set(mockKey, mockValue);
-    await kv.setSafeAtomic(mockKey, updateValue);
+    const result = await kv.setSafeAtomic(mockKey, updateValue);
     const { value: newValue } = await kv.get(mockKey);
     await kv.close();
 
     // Assert
     assertEquals(newValue, mockValue);
+    assertEquals(result, { ok: false, error: abortReason, value: mockValue })
   },
 );
 
@@ -96,13 +100,14 @@ Deno.test(
     const mockUpdatedValue1 = "new value 1";
     const mockUpdatedValue2 = "new value 2";
     const mockUpdatedValues = [mockUpdatedValue1, mockUpdatedValue2];
+    const abortReason = "Testing";
 
     const keys = [mockKey1, mockKey2];
     const updateValues = (
       _values: unknown[],
-      abort: () => void,
+      abort: (reason?: string) => void,
     ): unknown[] | void => {
-      abort();
+      abort(abortReason);
       return mockUpdatedValues;
     };
     const retryCount = 3;
@@ -113,7 +118,7 @@ Deno.test(
     await kv.set(mockKey2, mockValue2);
 
     // Act
-    await kv.setSafeAtomicMany(keys, updateValues, retryCount);
+    const result = await kv.setSafeAtomicMany(keys, updateValues, retryCount);
     const { value: newValue1 } = await kv.get(mockKey1);
     const { value: newValue2 } = await kv.get(mockKey2);
     await kv.close();
@@ -121,6 +126,7 @@ Deno.test(
     // Assert
     assertEquals(newValue1, mockValue1);
     assertEquals(newValue2, mockValue2);
+    assertEquals(result, { ok: false, error: abortReason, values: [mockValue1, mockValue2] });
   },
 );
 


### PR DESCRIPTION
`setSafeAtomic` and `setSafeAtomicMany` may or may not perform the update depending on:
- Whether or not `abort` is called
- Deno KV accepts the update

It's useful to know the new, up-to-date values that are in Deno KV as of the end of an update.